### PR TITLE
Add IDE Hints

### DIFF
--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
@@ -61,7 +61,7 @@ class CurseArtifact implements Serializable {
     @SerializedName("relations")
     CurseRelation curseRelations
 
-    void relations(Closure<?> configClosure) {
+    void relations(@DelegatesTo(CurseRelation)Closure<?> configClosure) {
         CurseRelation relation = new CurseRelation()
         relation.with(configClosure)
         curseRelations = relation

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseExtension.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseExtension.groovy
@@ -26,7 +26,7 @@ class CurseExtension {
      *
      * @param configClosure The configuration closure
      */
-    void project(Closure<?> configClosure) {
+    void project(@DelegatesTo(CurseProject) Closure<?> configClosure) {
         CurseProject curseProject = new CurseProject()
         curseProject.with(configClosure)
         if (curseProject.apiKey == null) {

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseProject.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseProject.groovy
@@ -66,7 +66,7 @@ class CurseProject {
      * @param artifact The artifact
      * @param configClosure Optional configuration closure
      */
-    void mainArtifact(def artifact, Closure<?> configClosure = null) {
+    void mainArtifact(def artifact, @DelegatesTo(CurseArtifact)Closure<?> configClosure = null) {
         CurseArtifact curseArtifact = new CurseArtifact()
         if (configClosure != null) {
             curseArtifact.with(configClosure)
@@ -81,7 +81,7 @@ class CurseProject {
      * @param artifact The artifact
      * @param configClosure Optional configuration closure
      */
-    void addArtifact(def artifact, Closure<?> configClosure = null) {
+    void addArtifact(def artifact, @DelegatesTo(CurseArtifact)Closure<?> configClosure = null) {
         CurseArtifact curseArtifact = new CurseArtifact()
         if (configClosure != null) {
             curseArtifact.with(configClosure)
@@ -104,7 +104,7 @@ class CurseProject {
      *
      * @param configureClosure The configuration closure
      */
-    void relations(Closure<?> configureClosure) {
+    void relations(@DelegatesTo(CurseRelation)Closure<?> configureClosure) {
         if (curseRelations == null) {
             curseRelations = new HashSet<>()
         }

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseRelation.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseRelation.groovy
@@ -6,14 +6,24 @@ import static com.matthewprenger.cursegradle.Util.check
 
 class CurseRelation implements Serializable {
 
-    // Create methods for each type of project relation
-    static {
-        CurseGradlePlugin.VALID_RELATIONS.each { relation ->
-            CurseRelation.metaClass."$relation" = { Object[] args ->
-                check(args.length == 1, "Invalid relation syntax for relation $relation")
-                projects.add(new Project(type: relation, slug: args[0]))
-            }
-        }
+    private void addRelation(String typeIn, String slugIn){
+        projects.add(new Project(type: typeIn, slug: slugIn))
+    }
+
+    void requiredLibrary(String slugIn) {
+        addRelation("requiredLibrary", slugIn)
+    }
+    void embeddedLibrary(String slugIn) {
+        addRelation("embeddedLibrary", slugIn)
+    }
+    void optionalLibrary(String slugIn) {
+        addRelation("optionalLibrary", slugIn)
+    }
+    void tool(String slugIn) {
+        addRelation("tool", slugIn)
+    }
+    void incompatible(String slugIn) {
+        addRelation("incompatible", slugIn)
     }
 
     // Catches a missing method exception and gives a more user friendly error message


### PR DESCRIPTION
The first commit adds hints that IDEs such as IDEA can read to determine autocompletion and type compatibility.

The second commit changes the `CurseRelation` functions to concrete members so that the IDE can see that they exist. I did this as a separate commit in case you really don't want it :)

Before/After:
![cursegradle](https://user-images.githubusercontent.com/1788847/32978894-f10bedf2-cc85-11e7-9a0d-1311868bb714.png)
(for the unfamiliar: grey & underlined = IDE can't resolve it, same for the white ones that are purple on the After)