### PR TITLE
Store the file Id of the artifact.

### DIFF
--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
@@ -20,6 +20,11 @@ class CurseArtifact implements Serializable {
     transient Collection<Object> gameVersionStrings
 
     /**
+     * The curseforge file ID of the artifact.
+     */
+    transient Integer fileID
+
+    /**
      * The type of changelog. At the time of writing this is: html and text
      */
     @SerializedName("changelogType")
@@ -60,11 +65,6 @@ class CurseArtifact implements Serializable {
 
     @SerializedName("relations")
     CurseRelation curseRelations
-
-    /**
-     * The curseforge file ID of the artifact.
-     */
-    Integer fileID
 
     void relations(@DelegatesTo(CurseRelation)Closure<?> configClosure) {
         CurseRelation relation = new CurseRelation()

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
@@ -58,6 +58,12 @@ class CurseArtifact implements Serializable {
     @SerializedName("parentFileID")
     Integer parentFileID
 
+    /**
+     * The curseforge file ID of the artifact.
+     */
+    @SerializedName("fileID")
+    Integer fileID
+
     @SerializedName("relations")
     CurseRelation curseRelations
 

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseArtifact.groovy
@@ -58,14 +58,13 @@ class CurseArtifact implements Serializable {
     @SerializedName("parentFileID")
     Integer parentFileID
 
+    @SerializedName("relations")
+    CurseRelation curseRelations
+
     /**
      * The curseforge file ID of the artifact.
      */
-    @SerializedName("fileID")
     Integer fileID
-
-    @SerializedName("relations")
-    CurseRelation curseRelations
 
     void relations(@DelegatesTo(CurseRelation)Closure<?> configClosure) {
         CurseRelation relation = new CurseRelation()

--- a/src/main/groovy/com/matthewprenger/cursegradle/CurseUploadTask.groovy
+++ b/src/main/groovy/com/matthewprenger/cursegradle/CurseUploadTask.groovy
@@ -45,12 +45,13 @@ class CurseUploadTask extends DefaultTask {
 
         final String json = Util.gson.toJson(mainArtifact)
         int mainID = uploadFile(json, (File) mainArtifact.artifact)
+        mainArtifact.fileID = mainID
 
         additionalArtifacts.each { artifact ->
             artifact.resolve(project)
             artifact.parentFileID = mainID
             final String childJson = Util.gson.toJson(artifact)
-            uploadFile(childJson, (File) artifact.artifact)
+            artifact.fileID = uploadFile(childJson, (File) artifact.artifact)
         }
     }
 


### PR DESCRIPTION
Allows users to access the curseforge file ID. Means that a user can create a task to access the file ID and do stuff with it. [For my use](https://github.com/Dumb-Code/DumbLibrary/blob/eddec291c9ed309329d08ac8361367075b1cfa72/build.gradle#L104-L112), I created a task that uploads to curseforge then sends a webhook with the file url. At the moment, as the file ID isn't stored, I have to do some unnecessary hacks like getting the parentID on the additional artifacts. This would allow me to just reference the file ID and go from there. 

Feel free to suggest any changes anywhere.