### PR TITLE
Have Travis CI use gradle wrapper to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ jdk:
   - openjdk8
 before_install:
   - chmod a+x gradlew
-script: gradle clean check
+script: ./gradlew clean check


### PR DESCRIPTION
Pretty self evident, CurseGradle packages a gradle wrapper in the git repo, this tells travis to actually use that wrapper instead of it's own system version.